### PR TITLE
ObservableObject support

### DIFF
--- a/MirrorUI/MirrorUI/MirrorView/MirrorView.swift
+++ b/MirrorUI/MirrorUI/MirrorView/MirrorView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Combine
 
 struct ObjectProperty: Identifiable {
     var id: String { name }
@@ -40,8 +41,13 @@ public struct MirrorView: View {
                 reloadTrigger.reload()
             }
             if let didSetCaller = property.objectRef as? InternalDidSetCaller {
-                didSetCaller.internalDidSet = {
+                didSetCaller.internalDidSet = { [weak object] in
                     reloadTrigger.reload()
+
+                    /// If the passed object is an ObservableObject, call send() on the publisher when values are updated.
+                    if let observableObject = object as? (any ObservableObject) {
+                        (observableObject.objectWillChange as any Publisher as? ObservableObjectPublisher)?.send()
+                    }
                 }
             }
         }

--- a/README.md
+++ b/README.md
@@ -65,7 +65,11 @@ To be able to present UI to edit a type, MirrorUI needs to have a 'mapping' to a
 
 *Enums must conform to `CaseIterable`. Enums that contain cases with associated values will require bespoke view mappings.
 
-## Callbacks
+## Observing changes
+
+If using `SwiftUI` or `Combine`, simply conform your object to `ObservableObject` and `MirrorUI` will publish changes for `@MirrorUI` properties in the same way that `@Published` does.
+
+## Change callbacks
 
 Properties using the `@MirrorUI` property wrapper will not trigger callbacks through property observers such as `didSet`.
 


### PR DESCRIPTION
`MirrorUI` will call `send()` on the object's publisher when properties change if it conforms to `ObservableObject`.